### PR TITLE
Make `did` work for empty directory lists

### DIFF
--- a/bin/did
+++ b/bin/did
@@ -21,7 +21,7 @@ fi >&2
 
 # Data acquisition
 
-dirs=$(grep -e '^[^#]' "$HOME/.config/did/$1")
+dirs=$(grep -e '^[^#]' "$HOME/.config/did/$1" || true)
 relative_dirs=$(echo "$dirs" | { grep -e '^[^/]' || true; })
 
 if [ -n "$relative_dirs" ]


### PR DESCRIPTION
This resolves #27.