### PR TITLE
Correct the copyright period of `cci`

### DIFF
--- a/bin/cci
+++ b/bin/cci
@@ -1,7 +1,7 @@
 #! /usr/bin/env sh
 
 
-# Copyright 2022–2024 Wolfgang Jeltsch
+# Copyright 2023–2024 Wolfgang Jeltsch
 #
 # Licensed under the Apache License, Version 2.0 (the “License”); you
 # may not use this file except in compliance with the License. You may


### PR DESCRIPTION
This changes the year stated as the start of the copyright period of `cci` from 2022 to the correct 2023.
